### PR TITLE
Expand node engine support for vue2 compatible build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vue-use-popperjs",
   "version": "1.3.2",
   "engines": {
-    "node": "^12.13.0 || ^14.15.0"
+    "node": "^12 || ^14 || ^16 || >=18"
   },
   "description": "Vue 2, 3 popper solution powered by @popperjs",
   "main": "dist/index.cjs.prod.js",


### PR DESCRIPTION
This addresses the below warning when installing `vue-use-popperjs@1.3.2` on more recent versions of node:

```
$ npm i vue-use-popperjs@^1
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'vue-use-popperjs@1.3.2',
npm WARN EBADENGINE   required: { node: '^12.13.0 || ^14.15.0' },
npm WARN EBADENGINE   current: { node: 'v18.5.0', npm: '8.12.1' }
npm WARN EBADENGINE }
```